### PR TITLE
Fix issue where permission error is marked as broken

### DIFF
--- a/pisi/operations/check.py
+++ b/pisi/operations/check.py
@@ -28,6 +28,8 @@ def file_corrupted(pfile):
                 return True
         except pisi.util.FilePermissionDeniedError, e:
             raise e
+        except pisi.util.FileNotFoundError, e:
+            raise e
     return False
 
 
@@ -80,25 +82,24 @@ def check_files(files, check_config=False):
         is_file_corrupted = False
 
         path = os.path.join(ctx.config.dest_dir(), f.path)
-        if pisi.util.path_could_exists(path):
-            try:
-                is_file_corrupted = file_corrupted(f)
+        try:
+            is_file_corrupted = file_corrupted(f)
 
-            except pisi.util.FilePermissionDeniedError, e:
-                # Can't read file, probably because of permissions, skip
-                results['denied'].append(f.path)
-
-            else:
-                if is_file_corrupted:
-                    # Detect file type
-                    if f.type == "config":
-                        results['config'].append(f.path)
-                    else:
-                        results['corrupted'].append(f.path)
-
-        else:
+        except pisi.util.FilePermissionDeniedError, e:
+            # Can't read file, probably because of permissions, skip
+            results['denied'].append(f.path)
+        
+        except pisi.util.FileNotFoundError, e:
             # Shipped file doesn't exist on the system
             results['missing'].append(f.path)
+
+        else:
+            if is_file_corrupted:
+                # Detect file type
+                if f.type == "config":
+                    results['config'].append(f.path)
+                else:
+                    results['corrupted'].append(f.path)
 
     return results
 

--- a/pisi/operations/check.py
+++ b/pisi/operations/check.py
@@ -80,7 +80,7 @@ def check_files(files, check_config=False):
         is_file_corrupted = False
 
         path = os.path.join(ctx.config.dest_dir(), f.path)
-        if os.path.lexists(path):
+        if pisi.util.path_could_exists(path):
             try:
                 is_file_corrupted = file_corrupted(f)
 

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -301,6 +301,21 @@ def join_path(a, *p):
             path += '/' + b
     return path
 
+def path_could_exists(path):
+    """
+    Returns True if the path exists, or if the path could exist, but is
+    uncheckable because we don't have permission to enter a parent dir.
+    """
+    if os.path.lexists(path):
+        return True
+
+    while True:
+        path = parenturi(path)
+        if os.path.lexists(path) and not os.access(path, os.R_OK):
+            return True
+        if path == '':
+            return False
+
 ####################################
 # File/Directory Related Functions #
 ####################################

--- a/pisi/util.py
+++ b/pisi/util.py
@@ -56,6 +56,8 @@ class FileError(Error):
 class FilePermissionDeniedError(Error):
     pass
 
+class FileNotFoundError(Error):
+    pass
 
 #########################
 # string/list/functional#
@@ -301,21 +303,6 @@ def join_path(a, *p):
             path += '/' + b
     return path
 
-def path_could_exists(path):
-    """
-    Returns True if the path exists, or if the path could exist, but is
-    uncheckable because we don't have permission to enter a parent dir.
-    """
-    if os.path.lexists(path):
-        return True
-
-    while True:
-        path = parenturi(path)
-        if os.path.lexists(path) and not os.access(path, os.R_OK):
-            return True
-        if path == '':
-            return False
-
 ####################################
 # File/Directory Related Functions #
 ####################################
@@ -489,6 +476,9 @@ def sha1_file(filename):
         if e.errno == 13:
             # Permission denied, the file doesn't have read permissions, skip
             raise FilePermissionDeniedError(_("You don't have necessary read permissions"))
+        elif e.errno == 2:
+            # File not found, skip
+            raise FileNotFoundError(_("File %s was not found") % filename)
         else:
             raise FileError(_("Cannot calculate SHA1 hash of %s") % filename)
 


### PR DESCRIPTION
If a path is inside a directory that we don't have permission to read, eopkg marks the related package as "Broken" instead of "Unknown".

This ensures that packages with files that we cannot read are always marked as "Unknown".

This namely fixes an issue where gnome-control-center, gvfs, libvirt, udisks, flatpak, and possibly other packages could be marked as "Broken" when running `eopkg check` without root.