### PR TITLE
Truncate progress output if console isn't wide enough

### DIFF
--- a/pisi/cli/__init__.py
+++ b/pisi/cli/__init__.py
@@ -59,6 +59,11 @@ class CLI(pisi.ui.UI):
                 out = sys.stderr
             else:
                 out = sys.stdout
+            rows, columns = os.popen('stty size', 'r').read().split()
+            cols = int(columns)
+            if len(msg) > cols:
+                maxlen = cols - 3
+                msg = msg[:maxlen]+ '...'
             out.write(msg)
             out.flush()
 


### PR DESCRIPTION
Always bothered me that eopkg would spam the progress output if the package name + progress was longer than the console. Hope this can be merged :)