### PR TITLE
Fix download size unit

### DIFF
--- a/pisi/util.py
+++ b/pisi/util.py
@@ -108,7 +108,7 @@ def human_readable_size(size = 0):
     symbols, depth = [' B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], 0
 
     while size > 1000 and depth < 8:
-        size = float(size / 1024)
+        size = float(size / 1000)
         depth += 1
 
     return size, symbols[depth]


### PR DESCRIPTION
Eopkg currently calculates "binary byte" units (KiB, MiB,....) but shows them as decimal power units (KB, MB,....)

See this discussion: https://discuss.getsol.us/d/6834-difference-between-software-center-and-terminal-update/19

This changes the calculation accordingly so it corresponds to the units shown to the user.

solus-sc PR to fix the exact opposite problem there: https://github.com/getsolus/solus-sc/pull/93