### PR TITLE
Force python2

### DIFF
--- a/eopkg-cli
+++ b/eopkg-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # Copyright (C) 2005 - 2010, TUBITAK/UEKAE
 #


### PR DESCRIPTION
some people change /usr/bin/python to point to python3, this breaks eopkg. should specify python2